### PR TITLE
sutler: RollingUpdate for api and web

### DIFF
--- a/kubernetes/apps/batcave/sutler/app/helmrelease.yaml
+++ b/kubernetes/apps/batcave/sutler/app/helmrelease.yaml
@@ -29,6 +29,15 @@ spec:
       api:
         annotations:
           reloader.stakater.com/auto: "true"
+        # app-template defaults to Recreate, which kills the old pod before
+        # the new one starts — a guaranteed outage per release, and a long one
+        # when the kill hangs (wally, 2026-08-22: 7 min of 503). Surge the new
+        # pod first; the old one goes only once the new has passed its startup
+        # probe. The worker stays Recreate: single process by design.
+        strategy: RollingUpdate
+        rollingUpdate:
+          surge: 1
+          unavailable: 0
         initContainers:
           # 1) create the sutler database + role on the shared CNPG cluster
           01-init-db:
@@ -147,6 +156,10 @@ spec:
               limits:
                 memory: 384Mi
       web:
+        strategy: RollingUpdate
+        rollingUpdate:
+          surge: 1
+          unavailable: 0
         containers:
           main:
             image:


### PR DESCRIPTION
app-template defaults every Deployment to `Recreate`, which kills the old pod **before** the new one starts — a guaranteed outage per release. On 2026-08-22 it was 7 minutes of 503 because containerd on wally hung the kill (`FailedKillPod … DeadlineExceeded`).

This sets `RollingUpdate` with `surge: 1, unavailable: 0` on **api** and **web**: the new pod must pass its startup probe before the old is told to stop, so a hung kill no longer affects availability. Still one replica each. The **worker stays `Recreate`** on purpose — BullMQ concurrency 1, the orphaned-sync cleanup at boot and the in-process token caches all assume a single process.

Note the api init chain (init-db → migrate → seed) runs in the surged pod while the old one still serves; migrations are additive and `prisma migrate deploy` takes an advisory lock, so this is the same ordering staging has always had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)